### PR TITLE
ENG-4009: Upgrade for Ruby 3.2

### DIFF
--- a/lib/rspec_api_documentation/writers/append_json_writer.rb
+++ b/lib/rspec_api_documentation/writers/append_json_writer.rb
@@ -5,7 +5,7 @@ module RspecApiDocumentation
     class AppendJsonWriter < JsonWriter
       def write
         index_file = docs_dir.join("index.json")
-        if File.exists?(index_file) && (output = File.read(index_file)).length >= 2
+        if File.exist?(index_file) && (output = File.read(index_file)).length >= 2
           existing_index_hash = JSON.parse(output)
         end
         File.open(index_file, "w+") do |f|

--- a/lib/rspec_api_documentation/writers/writer.rb
+++ b/lib/rspec_api_documentation/writers/writer.rb
@@ -14,7 +14,7 @@ module RspecApiDocumentation
       end
 
       def self.clear_docs(docs_dir)
-        if File.exists?(docs_dir)
+        if File.exist?(docs_dir)
           FileUtils.rm_rf(docs_dir, :secure => true)
         end
         FileUtils.mkdir_p(docs_dir)

--- a/spec/api_documentation_spec.rb
+++ b/spec/api_documentation_spec.rb
@@ -19,7 +19,7 @@ describe RspecApiDocumentation::ApiDocumentation do
       subject.clear_docs
 
       expect(File.directory?(configuration.docs_dir)).to be_truthy
-      expect(File.exists?(test_file)).to be_falsey
+      expect(File.exist?(test_file)).to be_falsey
     end
   end
 

--- a/spec/writers/html_writer_spec.rb
+++ b/spec/writers/html_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::HtmlWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.html")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end

--- a/spec/writers/json_iodocs_writer_spec.rb
+++ b/spec/writers/json_iodocs_writer_spec.rb
@@ -25,7 +25,7 @@ describe RspecApiDocumentation::Writers::JsonIodocsWriter do
     it "should write the index" do
       writer.write
       index_file = File.join(configuration.docs_dir, "apiconfig.json")
-      expect(File.exists?(index_file)).to be_truthy
+      expect(File.exist?(index_file)).to be_truthy
     end
   end
 end

--- a/spec/writers/json_writer_spec.rb
+++ b/spec/writers/json_writer_spec.rb
@@ -24,7 +24,7 @@ describe RspecApiDocumentation::Writers::JSONWriter do
     it "should write the index" do
       writer.write
       index_file = File.join(configuration.docs_dir, "index.json")
-      expect(File.exists?(index_file)).to be_truthy
+      expect(File.exist?(index_file)).to be_truthy
     end
   end
 end

--- a/spec/writers/markdown_writer_spec.rb
+++ b/spec/writers/markdown_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::MarkdownWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.md")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end

--- a/spec/writers/slate_writer_spec.rb
+++ b/spec/writers/slate_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::SlateWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.html.md")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end

--- a/spec/writers/textile_writer_spec.rb
+++ b/spec/writers/textile_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::TextileWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.textile")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
## Purpose
Prepare this repository for use with Ruby 3.2. Ruby 3.2 removes the deprecated method `File.exists?` in favor of `File.exist?`.

## Approach
We maintain a fork of this gem since it is unmaintained by the original author(s).

All usage of `File.exists?` in this repository is updated to `File.exist?`

A second PR updating the installed gem in `promote` will be made to upgrade this Gem in promote.